### PR TITLE
[TUBEMQ-19] Correct parameter names to fit in camel case

### DIFF
--- a/tubemq-server/src/main/java/com/tencent/tubemq/server/common/utils/JVMClusterUtil.java
+++ b/tubemq-server/src/main/java/com/tencent/tubemq/server/common/utils/JVMClusterUtil.java
@@ -81,7 +81,7 @@ public class JVMClusterUtil {
      * address.
      */
     public static void startup(final List<MasterThread> masters,
-                               final List<BrokerThread> regionservers) throws IOException {
+                               final List<BrokerThread> regionServers) throws IOException {
 
         if (masters == null || masters.isEmpty()) {
             return;
@@ -91,8 +91,8 @@ public class JVMClusterUtil {
             t.start();
         }
 
-        if (regionservers != null) {
-            for (JVMClusterUtil.BrokerThread t : regionservers) {
+        if (regionServers != null) {
+            for (JVMClusterUtil.BrokerThread t : regionServers) {
                 t.start();
             }
         }

--- a/tubemq-server/src/main/java/com/tencent/tubemq/server/common/utils/RowLock.java
+++ b/tubemq-server/src/main/java/com/tencent/tubemq/server/common/utils/RowLock.java
@@ -51,25 +51,25 @@ public class RowLock {
         this.name = lockName;
     }
 
-    public Integer getLock(Integer lockid, byte[] row, boolean waitForLock) throws IOException {
-        return getLock(lockid, new HashedBytes(row), waitForLock);
+    public Integer getLock(Integer lockId, byte[] row, boolean waitForLock) throws IOException {
+        return getLock(lockId, new HashedBytes(row), waitForLock);
     }
 
-    protected Integer getLock(Integer lockid,
+    protected Integer getLock(Integer lockId,
                               HashedBytes row,
                               boolean waitForLock) throws IOException {
         Integer lid;
-        if (lockid == null) {
+        if (lockId == null) {
             lid = internalObtainRowLock(row, waitForLock);
         } else {
-            HashedBytes rowFromLock = lockIds.get(lockid);
+            HashedBytes rowFromLock = lockIds.get(lockId);
             if (!row.equals(rowFromLock)) {
                 throw new IOException(new StringBuilder(512)
-                        .append("Invalid row lock: LockId: ").append(lockid)
+                        .append("Invalid row lock: LockId: ").append(lockId)
                         .append(" holds the lock for row: ").append(rowFromLock)
                         .append(" but wanted lock for row: ").append(row).toString());
             }
-            lid = lockid;
+            lid = lockId;
         }
         return lid;
     }


### PR DESCRIPTION
- JVMClusterUtil#startup : regionservers -> regionServers
- RowLock#getLock : lockid -> lockId

This closes #10 .